### PR TITLE
Delete deprecated depends.txt file

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,0 @@
-player_api
-biofuel
-default?
-creative?


### PR DESCRIPTION
Simply delete deprecated/unused `depends.txt` file.