### PR TITLE
Settings for Customizing Values

### DIFF
--- a/heli_control.lua
+++ b/heli_control.lua
@@ -1,6 +1,6 @@
 --global constants
 
-helicopter.gravity = tonumber(minetest.settings:get("movement_gravity")) or 9.8
+helicopter.gravity = tonumber(minetest.settings:get("movement_gravity") or 9.8)
 helicopter.tilting_speed = 1
 helicopter.tilting_max = 0.20
 helicopter.power_max = 15

--- a/heli_control.lua
+++ b/heli_control.lua
@@ -1,6 +1,5 @@
 --global constants
 
-helicopter.gravity = tonumber(minetest.settings:get("movement_gravity") or 9.8)
 helicopter.tilting_speed = 1
 helicopter.tilting_max = 0.20
 helicopter.power_max = 15

--- a/heli_crafts.lua
+++ b/heli_crafts.lua
@@ -24,21 +24,27 @@ minetest.register_craftitem("helicopter:heli", {
 		if minetest.get_node(pointed_thing.above).name ~= "air" then
 			return
 		end
-       
-        local obj = minetest.add_entity(pointed_thing.above, "helicopter:heli")
-        local ent = obj:get_luaentity()
-        --local imeta = itemstack:get_meta()
-        local owner = placer:get_player_name()
-        ent.owner = owner
-        --[[
-        ent.energy = imeta:get_int("energy")
-        ent.hp = imeta:get_int("hp")]]--
 
-        local properties = ent.object:get_properties()
-        properties.infotext = owner .. " nice helicopter"
-        ent.object:set_properties(properties)
+		local imeta = itemstack:get_meta()
+		local color = imeta:get_string("color")
+		if color == "" then color = nil end
+		local fuel = math.floor(imeta:get_float("fuel") * 100) / 100
 
-		if not (creative_exists and placer and
+		local obj = minetest.add_entity(pointed_thing.above, "helicopter:heli")
+		local ent = obj:get_luaentity()
+		local owner = placer:get_player_name()
+		ent.owner = owner
+		ent.energy = fuel
+		helicopter.updateIndicator(ent)
+		if color then
+			helicopter.paint(ent, color)
+		end
+
+		local properties = ent.object:get_properties()
+		properties.infotext = owner .. " nice helicopter"
+		ent.object:set_properties(properties)
+
+		if not (helicopter.creative and placer and
 				creative.is_enabled_for(placer:get_player_name())) then
 			itemstack:take_item()
 		end

--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -291,7 +291,7 @@ minetest.register_entity("helicopter:heli", {
             end
 
             if self.hp_max <= 0 then
-                if helicopter.pick_up then
+                if helicopter.punch_inv then
                     local pinv = puncher:get_inventory()
                     local stack = ItemStack("helicopter:heli")
                     local imeta = stack:get_meta()

--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -50,7 +50,7 @@ minetest.register_entity("helicopter:heli", {
     hp_max = 50,
     color = "#0063b0",
     _passenger = nil,
-    _by_mouse = false,
+    _by_mouse = helicopter.turn_player_look,
 
     get_staticdata = function(self) -- unloaded/unloads ... is now saved
         return minetest.serialize({

--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -280,6 +280,10 @@ minetest.register_entity("helicopter:heli", {
                         minetest.chat_send_player(puncher:get_player_name(),
                             "You do not have room in your inventory")
                     else
+                        if self.pointer then self.pointer:remove() end
+                        if self.pilot_seat_base then self.pilot_seat_base:remove() end
+                        if self.passenger_seat_base then self.passenger_seat_base:remove() end
+
                         self.object:remove()
                         pinv:add_item("main", stack)
                     end

--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -273,7 +273,12 @@ minetest.register_entity("helicopter:heli", {
             end
 
             if self.hp_max <= 0 then
-                helicopter.destroy(self, puncher)
+                if helicopter.pick_up then
+                    self.object:remove()
+                    puncher:get_inventory():add_item("main", "helicopter:heli")
+                else
+                    helicopter.destroy(self, puncher)
+                end
             end
 
         end

--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -274,8 +274,15 @@ minetest.register_entity("helicopter:heli", {
 
             if self.hp_max <= 0 then
                 if helicopter.pick_up then
-                    self.object:remove()
-                    puncher:get_inventory():add_item("main", "helicopter:heli")
+                    local pinv = puncher:get_inventory()
+                    local stack = ItemStack("helicopter:heli")
+                    if not pinv:room_for_item("main", stack) then
+                        minetest.chat_send_player(puncher:get_player_name(),
+                            "You do not have room in your inventory")
+                    else
+                        self.object:remove()
+                        pinv:add_item("main", stack)
+                    end
                 else
                     helicopter.destroy(self, puncher)
                 end

--- a/heli_fuel_management.lua
+++ b/heli_fuel_management.lua
@@ -12,18 +12,18 @@ initial_properties = {
 	mesh = "pointer.b3d",
 	textures = {"clay.png"},
 	},
-	
+
 on_activate = function(self,std)
 	self.sdata = minetest.deserialize(std) or {}
 	if self.sdata.remove then self.object:remove() end
 end,
-	
+
 get_staticdata=function(self)
-  	
+
   self.sdata.remove=true
   return minetest.serialize(self.sdata)
 end,
-	
+
 })
 
 function helicopter.get_gauge_angle(value)
@@ -40,6 +40,13 @@ function helicopter.contains(table, val)
         end
     end
     return false
+end
+
+function helicopter.updateIndicator(self)
+	local energy_indicator_angle = helicopter.get_gauge_angle(self.energy)
+	self.pointer:set_attach(self.object, '',
+		{x=0, y=11.26, z=9.37},
+		{x=0, y=0, z=energy_indicator_angle})
 end
 
 function helicopter.loadFuel(self, player_name)
@@ -60,10 +67,9 @@ function helicopter.loadFuel(self, player_name)
             self.energy = self.energy + fuel
             if self.energy > 10 then self.energy = 10 end
 
-            local energy_indicator_angle = helicopter.get_gauge_angle(self.energy)
-            self.pointer:set_attach(self.object,'',{x=0,y=11.26,z=9.37},{x=0,y=0,z=energy_indicator_angle})
+            helicopter.updateIndicator(self)
         end
-        
+
         return true
     end
 

--- a/heli_fuel_management.lua
+++ b/heli_fuel_management.lua
@@ -51,6 +51,8 @@ end
 
 function helicopter.loadFuel(self, player_name)
     local player = minetest.get_player_by_name(player_name)
+    if not player then return end
+
     local inv = player:get_inventory()
 
     local itmstck=player:get_wielded_item()

--- a/heli_utilities.lua
+++ b/heli_utilities.lua
@@ -1,4 +1,4 @@
-helicopter.gravity = tonumber(minetest.settings:get("movement_gravity")) or 9.8
+helicopter.gravity = tonumber(minetest.settings:get("movement_gravity") or 9.8)
 helicopter.vector_up = vector.new(0, 1, 0)
 
 function helicopter.get_hipotenuse_value(point1, point2)

--- a/heli_utilities.lua
+++ b/heli_utilities.lua
@@ -1,4 +1,4 @@
-helicopter.gravity = tonumber(minetest.settings:get("movement_gravity") or 9.8)
+
 helicopter.vector_up = vector.new(0, 1, 0)
 
 function helicopter.get_hipotenuse_value(point1, point2)

--- a/init.lua
+++ b/init.lua
@@ -49,7 +49,7 @@ if not minetest.global_exists("matrix3") then
 	dofile(minetest.get_modpath("helicopter") .. DIR_DELIM .. "matrix.lua")
 end
 
-local creative_exists = minetest.global_exists("creative")
+helicopter.creative = minetest.global_exists("creative")
 
 function helicopter.check_is_under_water(obj)
 	local pos_up = obj:get_pos()

--- a/init.lua
+++ b/init.lua
@@ -29,6 +29,7 @@ helicopter.colors ={
     yellow='#ffe400',
 }
 
+dofile(minetest.get_modpath("helicopter") .. DIR_DELIM .. "settings.lua")
 --dofile(minetest.get_modpath(minetest.get_current_modname()) .. DIR_DELIM .. "heli_hud.lua")
 dofile(minetest.get_modpath("helicopter") .. DIR_DELIM .. "heli_hud.lua")
 dofile(minetest.get_modpath("helicopter") .. DIR_DELIM .. "heli_utilities.lua")

--- a/settings.lua
+++ b/settings.lua
@@ -6,7 +6,7 @@ helicopter.gravity = tonumber(minetest.settings:get("movement_gravity") or 9.8)
 --
 --  If `false`, helicopter is destroyed. Otherwise, it is added to inventory.
 --    - Default: false
-helicopter.pick_up = minetest.settings:get_bool("helicopter.pick_up", false)
+helicopter.punch_inv = minetest.settings:get_bool("mount_punch_inv", false)
 
 --- Determines default control of helicopter.
 --

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,6 @@
+
+--- Determines handling of punched helicopter.
+--
+-- If `false`, helicopter is destroyed. Otherwise, it is added to inventory.
+--   - Default: false
+helicopter.pick_up = minetest.settings:get_bool("helicopter.pick_up", false)

--- a/settings.lua
+++ b/settings.lua
@@ -1,4 +1,7 @@
 
+--- Determines gravity force on helicopter.
+helicopter.gravity = tonumber(minetest.settings:get("movement_gravity") or 9.8)
+
 --- Determines handling of punched helicopter.
 --
 --  If `false`, helicopter is destroyed. Otherwise, it is added to inventory.

--- a/settings.lua
+++ b/settings.lua
@@ -1,6 +1,12 @@
 
 --- Determines handling of punched helicopter.
 --
--- If `false`, helicopter is destroyed. Otherwise, it is added to inventory.
---   - Default: false
+--  If `false`, helicopter is destroyed. Otherwise, it is added to inventory.
+--    - Default: false
 helicopter.pick_up = minetest.settings:get_bool("helicopter.pick_up", false)
+
+--- Determines default control of helicopter.
+--
+--  Use facing direction to turn instead of a/d keys by default.
+--    - Default: false
+helicopter.turn_player_look = minetest.settings:get_bool("mount_turn_player_look", false)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,7 +1,7 @@
 
 # If enabled, places helicopter in inventory instead of destroying it
 # when punched.
-helicopter.pick_up (Place in inventory) bool false
+mount_punch_inv (Place in inventory) bool false
 
 # Use facing direction to turn instead of a/d keys by default.
 mount_turn_player_look (Turn with look direction) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,7 @@
 
+# Determines gravity force on helicopter.
+movement_gravity (Movement gravity) float 9.8
+
 # If enabled, places helicopter in inventory instead of destroying it
 # when punched.
 helicopter.pick_up (Place in inventory) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -2,3 +2,6 @@
 # If enabled, places helicopter in inventory instead of destroying it
 # when punched.
 helicopter.pick_up (Place in inventory) bool false
+
+# Use facing direction to turn instead of a/d keys by default.
+mount_turn_player_look (Turn with look direction) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,7 +1,4 @@
 
-# Determines gravity force on helicopter.
-movement_gravity (Movement gravity) float 9.8
-
 # If enabled, places helicopter in inventory instead of destroying it
 # when punched.
 helicopter.pick_up (Place in inventory) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,4 @@
+
+# If enabled, places helicopter in inventory instead of destroying it
+# when punched.
+helicopter.pick_up (Place in inventory) bool false


### PR DESCRIPTION
Adds two settings:
- `mount_punch_inv`
    - If enabled, places helicopter in inventory instead of breaking it.
    - default: `false`
- `mount_turn_player_look`
    - If enabled, uses mouse for control by default.
    - default: `false`

Also adds some fixes for the `movement_gravity` setting.

Having the option to use mouse as default is good because mouse control is much easier in the mobile Android app. And the app does not have any way to execute "e" keypress without giving focus to chat input.