### PR TITLE
handle players on destroy

### DIFF
--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -235,15 +235,12 @@ minetest.register_entity("nss_helicopter:heli", {
 			return
 		end
 		local name = puncher:get_player_name()
-        if self.owner and self.owner ~= name and self.owner ~= "" then return end
+        if self.owner and self.owner ~= name and self.owner ~= "" then
+            if not minetest.check_player_privs(puncher, {protection_bypass=true}) then return end
+        end
         if self.owner == nil then
             self.owner = name
         end
-
-        if self.driver_name and self.driver_name ~= name then
-			-- do not allow other players to remove the object while there is a driver
-			return
-		end
 
         local touching_ground, liquid_below = helicopter.check_node_below(self.object)
 

--- a/heli_utilities.lua
+++ b/heli_utilities.lua
@@ -127,13 +127,13 @@ function helicopter.destroy(self, puncher)
     end
 
     if self.driver_name then
-        -- detach the driver first (puncher must be driver)
-        puncher:set_detach()
-        puncher:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
-        player_api.player_attached[name] = nil
-        -- player should stand again
-        player_api.set_animation(puncher, "stand")
-        self.driver_name = nil
+        local driver = minetest.get_player_by_name(self.driver_name)
+        helicopter.dettach(self, driver)
+    end
+
+    if self._passenger then
+        local passenger = minetest.get_player_by_name(self._passenger)
+        helicopter.dettach_pax(self, passenger)
     end
 
     local pos = self.object:get_pos()


### PR DESCRIPTION
on destruction not the puncher should be detached, but instead the people inside the helicopter (driver, passenger)

this also allows dropping the safeguards. i'm not even sure if disabling punching the helicopter is sufficient. couldn't there be other cases where the helicopter gets destroyed with somebody in it?

and add an exception for players with protection bypass, so the server-admin can punch/remove helicopters belonging to other players