### PR TITLE
[Idea] remove helicopter in multiplayer protected areas

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -2,3 +2,5 @@ player_api
 biofuel
 default?
 creative?
+areas?
+protector?

--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -235,9 +235,13 @@ minetest.register_entity("nss_helicopter:heli", {
 			return
 		end
 		local name = puncher:get_player_name()
+
         if self.owner and self.owner ~= name and self.owner ~= "" then
-            if not minetest.check_player_privs(puncher, {protection_bypass=true}) then return end
+            local is_admin = minetest.check_player_privs(puncher, {protection_bypass=true})
+            local is_area_owner = helicopter.isAreaProtectedBy(self, puncher)
+            if not is_admin and not is_area_owner then return end
         end
+
         if self.owner == nil then
             self.owner = name
         end

--- a/heli_entities.lua
+++ b/heli_entities.lua
@@ -235,15 +235,12 @@ minetest.register_entity("nss_helicopter:heli", {
 			return
 		end
 		local name = puncher:get_player_name()
-        if self.owner and self.owner ~= name and self.owner ~= "" then return end
+        if self.owner and self.owner ~= name and self.owner ~= "" then
+            if not minetest.check_player_privs(puncher, {protection_bypass=true}) then return end
+        end
         if self.owner == nil then
             self.owner = name
         end
-
-        if self.driver_name and self.driver_name ~= name then
-			-- do not allow other players to remove the object while there is a driver
-			return
-		end
 
         local touching_ground, liquid_below = helicopter.check_node_below(self.object)
 

--- a/heli_utilities.lua
+++ b/heli_utilities.lua
@@ -127,13 +127,13 @@ function helicopter.destroy(self, puncher)
     end
 
     if self.driver_name then
-        -- detach the driver first (puncher must be driver)
-        puncher:set_detach()
-        puncher:set_eye_offset({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
-        player_api.player_attached[name] = nil
-        -- player should stand again
-        player_api.set_animation(puncher, "stand")
-        self.driver_name = nil
+        local driver = minetest.get_player_by_name(self.driver_name)
+        helicopter.dettach(self, driver)
+    end
+
+    if self._passenger then
+        local passenger = minetest.get_player_by_name(self._passenger)
+        helicopter.dettach_pax(self, passenger)
     end
 
     local pos = self.object:get_pos()

--- a/heli_utilities.lua
+++ b/heli_utilities.lua
@@ -160,3 +160,35 @@ function helicopter.destroy(self, puncher)
     minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'default:copperblock')
     minetest.add_item({x=pos.x+math.random()-0.5,y=pos.y,z=pos.z+math.random()-0.5},'nss_helicopter:blades')
 end
+
+function helicopter.isAreaProtectedBy(self, player)
+    local name = player:get_player_name()
+    local pos = self.object:get_pos()
+
+    if minetest.get_modpath("areas") then
+        local area_owners = areas:getNodeOwners(pos)
+        for _, value in pairs(area_owners) do
+            if value == name then
+                return true
+            end
+        end
+    end
+
+    if minetest.get_modpath("protector") then
+        -- use improvised find_nodes check
+        local protector_radius = tonumber(minetest.settings:get("protector_radius")) or 5
+        -- find the protector nodes
+        local protector_pos = minetest.find_nodes_in_area(
+            {x = pos.x - r, y = pos.y - r, z = pos.z - r},
+            {x = pos.x + r, y = pos.y + r, z = pos.z + r},
+            {"protector:protect", "protector:protect2", "protector:protect_hidden"})
+        for n = 1, #protector_pos do
+            local meta = minetest.get_meta(protector_pos[n])
+            local owner = meta:get_string("owner") or ""
+            if owner == name then
+                return true
+            end
+        end
+    end
+    return false
+end

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = nss_helicopter
 depends = player_api, biofuel
-optional_depends = default, creative
+optional_depends = default, creative, areas, protector
 description = It adds an expensive helicopter with power consumption. It uses biofuel to fly. With biofuel barrels on your inventory, you can recharge your helicopter attaching himself into it (with right click on seat) and punching the seat after. It does not refuel on flying, only when landed. The power consumption increases as high you climb, so, stay below the flight level 100.
 title = Not So Simple Helicopter


### PR DESCRIPTION
Another idea:
On multiplayer servers, someone could fly into your protected area and put their helicopters there. you wouldn't be able to do anything against that.

I don't know how other mods handle that.

This request builds upon the other pull request which grants the admin the ability to remove helicopters and also grants land owners that ability to remove them.

EDIT: I haven't tested this, yet.