### PR TITLE
Add Support for more fuel types based on mods installed

### DIFF
--- a/heli_crafts.lua
+++ b/heli_crafts.lua
@@ -48,6 +48,9 @@ minetest.register_craftitem("nss_helicopter:heli", {
 				creative.is_enabled_for(placer:get_player_name())) then
 			itemstack:take_item()
 		end
+		if not minetest.get_modpath('biofuels') and not minetest.get_modpath('techage') then
+			minetest.chat_send_player(placer:get_player_name(), '[Helicopter] Techage or biofuels mod is required for compatible fuel sources')
+		end
 		return itemstack
 	end,
 })

--- a/heli_crafts.lua
+++ b/heli_crafts.lua
@@ -48,8 +48,8 @@ minetest.register_craftitem("nss_helicopter:heli", {
 				creative.is_enabled_for(placer:get_player_name())) then
 			itemstack:take_item()
 		end
-		if not minetest.get_modpath('biofuels') and not minetest.get_modpath('techage') then
-			minetest.chat_send_player(placer:get_player_name(), '[Helicopter] Techage or biofuels mod is required for compatible fuel sources')
+		if not minetest.get_modpath('biofuel') and not minetest.get_modpath('techage') then
+			minetest.chat_send_player(placer:get_player_name(), '[Helicopter] Techage or biofuel mod is required for compatible fuel sources')
 		end
 		return itemstack
 	end,

--- a/heli_fuel_management.lua
+++ b/heli_fuel_management.lua
@@ -1,7 +1,14 @@
 --
 -- fuel
 --
-helicopter.fuel = {['biofuel:biofuel'] = 1,['biofuel:bottle_fuel'] = 1,['biofuel:phial_fuel'] = 0.25, ['biofuel:fuel_can'] = 10}
+helicopter.fuel = {
+	['biofuel:biofuel'] = { qty = 1 },
+	['biofuel:bottle_fuel'] = { qty = 1 },
+	['biofuel:phial_fuel'] = { qty = 0.25 },
+	['biofuel:fuel_can'] = { qty = 10 },
+	['techage:ta3_canister_gasoline'] = { qty = 1, container = 'techage:ta3_canister_empty' },
+	['techage:ta3_barrel_gasoline'] = { qty = 10, container = 'techage:ta3_barrel_empty' },
+}
 
 minetest.register_entity("nss_helicopter:pointer",{
 initial_properties = {
@@ -64,11 +71,15 @@ function helicopter.loadFuel(self, player_name)
     if fuel then
         stack = ItemStack(item_name .. " 1")
 
-        if self.energy < 10 then
+        if self.energy < 10 then -- should return empty containers
             local taken = inv:remove_item("main", stack)
-            self.energy = self.energy + fuel
+            self.energy = self.energy + fuel.qty
             if self.energy > 10 then self.energy = 10 end
 
+	    if fuel.container ~= nil then
+		    local returned = inv:add_item("main", ItemStack(fuel.container .." 1"))
+		    if not returned then minetest.log("warning", "[helicopter]: failed to return empty container on refuel: ".. fuel.container) end
+	    end
             helicopter.updateIndicator(self)
         end
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = nss_helicopter
-depends = player_api, biofuel
-optional_depends = default, creative
+depends = player_api
+optional_depends = default, creative, biofuel, techage
 description = It adds an expensive helicopter with power consumption. It uses biofuel to fly. With biofuel barrels on your inventory, you can recharge your helicopter attaching himself into it (with right click on seat) and punching the seat after. It does not refuel on flying, only when landed. The power consumption increases as high you climb, so, stay below the flight level 100.
 title = Not So Simple Helicopter


### PR DESCRIPTION
This update makes biofuels and techage optional dependencies and allows the use of techage gasoline as a fuel source for the helicopter.